### PR TITLE
Fix navbar close effect and lint

### DIFF
--- a/src/components/CustomLink.tsx
+++ b/src/components/CustomLink.tsx
@@ -27,7 +27,7 @@ export default function CustomLink({
     e.preventDefault()
     if (onClick) onClick()
 
-    let path = typeof href === 'string' ? href : href.pathname || '/'
+    const path = typeof href === 'string' ? href : href.pathname || '/'
 
     const finalQuery = {
       ...(query || {}),

--- a/src/components/navbar/MobileMenu.tsx
+++ b/src/components/navbar/MobileMenu.tsx
@@ -130,7 +130,7 @@ export default function MobileMenu({
     if (isOpen) {
       onClose()
     }
-  }, [pathname])
+  }, [pathname, isOpen, onClose])
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {


### PR DESCRIPTION
## Summary
- fix variable const in `CustomLink`
- close mobile menu correctly when navigating by including dependencies

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846f69ddcf4833081c99ef4637191e6