### PR TITLE
Improve logo navigation behavior

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import {
   FaPhoneAlt,
   FaLine,
@@ -11,8 +12,18 @@ import {
 } from 'react-icons/fa'
 
 export default function Footer() {
+  const pathname = usePathname()
   const handleLogoClick = () => {
-    window.location.href = '/?scrollToHero=true'
+    if (pathname === '/') {
+      const target = document.getElementById('herosection')
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth' })
+      } else {
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+      }
+    } else {
+      window.location.href = '/?scrollToHero=true'
+    }
   }
 
   return (

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -6,7 +6,10 @@ import TypewriterText from '@/components/TypewriterText'
 
 export default function HeroSection() {
   return (
-    <section className="relative min-h-[calc(100vh-0px)] lg:pt-25 flex items-center justify-center text-center px-6 bg-[#FFFEFE] snap-start">
+    <section
+      id="herosection"
+      className="relative min-h-[calc(100vh-0px)] lg:pt-25 flex items-center justify-center text-center px-6 bg-[#FFFEFE] snap-start"
+    >
       {/* Background image */}
       <div className="absolute inset-0 z-0 bg-[url('/bg-hero.png')] bg-cover bg-center opacity-15"></div>
 

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -42,7 +42,16 @@ export default function Navbar() {
   }, [])
 
   const handleLogoClick = () => {
-    window.location.href = '/?scrollToHero=true'
+    if (pathname === '/') {
+      const target = document.getElementById('herosection')
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth' })
+      } else {
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+      }
+    } else {
+      window.location.href = '/?scrollToHero=true'
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- smooth scroll on current page when clicking the logo
- redirect and reload to homepage otherwise
- add id to `HeroSection` for scroll targeting

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fa6df4588330b9da480b5b352d47