### PR TITLE
Replace Geist font variables

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-th);
+  --font-mono: var(--font-en);
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- update font variables in `globals.css` to use local fonts

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479e9d866083308b7b26aa29d2f4d4