### PR TITLE
Add StructuredData component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css'
 import { Prompt, Inter } from 'next/font/google'
 import Navbar from '@/components/navbar/Navbar'
+import StructuredData from '@/components/StructuredData'
 
 const fontTH = Prompt({
   subsets: ['thai'],
@@ -22,6 +23,9 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="th">
+      <head>
+        <StructuredData />
+      </head>
       <body className={`${fontTH.variable} ${fontEN.variable} font-[var(--font-th)] overflow-y-scroll scroll-smooth`}>
         <Navbar />
         <main className="pt-[72px] h-[calc(100vh-0px)] overflow-y-auto snap-y snap-mandatory scroll-smooth">

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  url: "https://virintira.com/",
+  name: "Virintira Accounting Office",
+}
+
+export default function StructuredData() {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- add script with company structured data
- load script from root layout

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6847a337a644833086354f8e9ca6819f