### PR TITLE
Add sitemap metadata route

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,10 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://virintira.com/',
+      lastModified: new Date(),
+    },
+  ]
+}


### PR DESCRIPTION
## Summary
- add metadata route file `src/app/sitemap.ts` that provides sitemap data

## Testing
- `npx tsc --noEmit` *(fails: Could not find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6847a42c814083308972d3e2e0b98f94