### PR TITLE
Update sitemap with extra pages

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,9 +1,19 @@
 import { MetadataRoute } from 'next'
 
+// Temporary sitemap; it will expand as new pages appear.
+
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: 'https://virintira.com/',
+      lastModified: new Date(),
+    },
+    {
+      url: 'https://virintira.com/promotion',
+      lastModified: new Date(),
+    },
+    {
+      url: 'https://virintira.com/under-construction',
       lastModified: new Date(),
     },
   ]


### PR DESCRIPTION
## Summary
- expand the sitemap with links for `/promotion` and `/under-construction`
- note that the sitemap is temporary and will grow over time

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847d8047acc8330821f85f7d413d54e