### PR TITLE
Fix mobile menu closing immediately

### DIFF
--- a/src/components/navbar/MobileMenu.tsx
+++ b/src/components/navbar/MobileMenu.tsx
@@ -127,10 +127,8 @@ export default function MobileMenu({
   }, [isOpen])
 
   useEffect(() => {
-    if (isOpen) {
-      onClose()
-    }
-  }, [pathname, isOpen, onClose])
+    onClose()
+  }, [pathname, onClose])
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {


### PR DESCRIPTION
## Summary
- update the pathname change effect in `MobileMenu` so it doesn't run when the menu opens

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848336238b48330bd9264736e00c3f2