### PR TITLE
Fix MobileMenu useEffect dependencies

### DIFF
--- a/src/components/navbar/MobileMenu.tsx
+++ b/src/components/navbar/MobileMenu.tsx
@@ -128,7 +128,7 @@ export default function MobileMenu({
 
   useEffect(() => {
     onClose()
-  }, [pathname])
+  }, [pathname, onClose])
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -144,7 +144,7 @@ export default function MobileMenu({
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
     }
-  }, [isOpen])
+  }, [isOpen, onClose])
 
   return (
     <div

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image from 'next/image'
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { usePathname } from 'next/navigation'
 import MegaMenu from './MegaMenu'
 import LanguageSwitcher from './LanguageSwitcher'
@@ -17,6 +17,10 @@ export default function Navbar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const hideTimer = useRef<NodeJS.Timeout | null>(null)
   const pathname = usePathname()
+
+  const handleCloseMenu = useCallback(() => {
+    setMobileMenuOpen(false)
+  }, [])
 
   const handleMouseEnter = () => {
     if (hideTimer.current) clearTimeout(hideTimer.current)
@@ -152,7 +156,7 @@ export default function Navbar() {
         </div>
       </div>
 
-      <MobileMenu isOpen={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} />
+      <MobileMenu isOpen={mobileMenuOpen} onClose={handleCloseMenu} />
       <SocialFloating menuOpen={mobileMenuOpen} />
     </header>
   )


### PR DESCRIPTION
## Summary
- memoize mobile menu close handler with `useCallback`
- add `onClose` to MobileMenu's `useEffect` dependencies

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484d2f05a4833089e31669b7208d1e