### PR TITLE
Refactor pages to use Suspense wrapper

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
 import HeroSection from '@/components/HeroSection'
@@ -8,7 +9,7 @@ import AboutSection from '@/components/AboutSection'
 import WhyChooseUsSection from '@/components/WhyChooseUsSection'
 import HowItWorksSection from '@/components/HowItWorksSection'
 
-export default function HomePage() {
+function HomePageContent() {
   const searchParams = useSearchParams()
 
   useEffect(() => {
@@ -38,5 +39,13 @@ export default function HomePage() {
       <WhyChooseUsSection />
       <HowItWorksSection />
     </>
+  )
+}
+
+export default function HomePage() {
+  return (
+    <Suspense fallback={null}>
+      <HomePageContent />
+    </Suspense>
   )
 }

--- a/src/app/under-construction/page.tsx
+++ b/src/app/under-construction/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 import ContactCTA from '@/components/ContactCTA'
 import BorderRevealButton from '@/components/BorderRevealButton'
@@ -19,7 +20,7 @@ function useIsMobile() {
   return isMobile
 }
 
-export default function UnderConstructionPage() {
+function UnderConstructionContent() {
   const searchParams = useSearchParams()
   const section = searchParams.get('section') || 'หมวดหมู่ไม่ระบุ'
   const item = searchParams.get('item') || 'หัวข้อไม่ระบุ'
@@ -58,5 +59,13 @@ export default function UnderConstructionPage() {
         </div>
       </div>
     </div>
+  )
+}
+
+export default function UnderConstructionPage() {
+  return (
+    <Suspense fallback={null}>
+      <UnderConstructionContent />
+    </Suspense>
   )
 }


### PR DESCRIPTION
## Summary
- wrap `/` and `/under-construction` pages in `Suspense`
- move search param logic into inner components to avoid warnings

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68485baeb9388330902ab73ac16effd2