### PR TITLE
Fix scroll-jump on initial load

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -80,9 +80,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <StructuredData />
       </head>
-      <body className={`${fontTH.variable} ${fontEN.variable} font-[var(--font-th)] overflow-y-scroll scroll-smooth`}>
+      <body className={`${fontTH.variable} ${fontEN.variable} font-[var(--font-th)] overflow-y-hidden`}>
         <Navbar />
-        <main className="pt-[72px] h-[calc(100vh-0px)] overflow-y-auto snap-y snap-mandatory scroll-smooth">
+        <main className="pt-[72px] h-[calc(100vh-0px)] overflow-y-auto snap-y snap-mandatory scroll-smooth scroll-pt-[72px]">
           {children}
           <Footer />
         </main>


### PR DESCRIPTION
## Summary
- keep root body from scrolling
- add scroll padding to align snap points under fixed header

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68486fb6a0a083308d239df37139d157