### PR TITLE
Fix initial header height

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,8 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
-  --header-height: 0px;
+  /* Approximate navbar height to prevent initial layout shift */
+  --header-height: 72px;
 }
 
 @theme inline {


### PR DESCRIPTION
## Summary
- prevent initial layout shift by assigning a default `--header-height`

## Testing
- `npx next lint` *(fails: Need to install next@15.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_684891d0221c833081ab1c56aff82a3b