### PR TITLE
Set header height default

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,8 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
-  --header-height: 0px;
+  /* Default header height to avoid layout shift before JS loads */
+  --header-height: 72px;
 }
 
 @theme inline {

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -24,6 +24,7 @@ export default function Navbar() {
   const hideTimer = useRef<NodeJS.Timeout | null>(null)
   const pathname = usePathname()
   const headerRef = useRef<HTMLElement | null>(null)
+  const DEFAULT_HEADER_HEIGHT = 72
 
   const handleCloseMenu = useCallback(() => {
     setMobileMenuOpen(false)
@@ -67,11 +68,17 @@ export default function Navbar() {
 
   useLayoutEffect(() => {
     const setHeight = () => {
-      if (headerRef.current) {
-        document.documentElement.style.setProperty(
-          '--header-height',
-          `${headerRef.current.offsetHeight}px`
-        )
+      const header = headerRef.current
+      if (!header) return
+      const height = header.offsetHeight
+      const root = document.documentElement
+      const current = parseFloat(
+        getComputedStyle(root).getPropertyValue('--header-height')
+      )
+      if (height !== DEFAULT_HEADER_HEIGHT || current !== DEFAULT_HEADER_HEIGHT) {
+        if (height !== current) {
+          root.style.setProperty('--header-height', `${height}px`)
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- use 72px header height in CSS
- sync CSS variable to measured height only when needed

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849c4880c088330aaa2f7a672d698f4