### PR TITLE
Use dynamic viewport units

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -82,7 +82,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className={`${fontTH.variable} ${fontEN.variable} font-[var(--font-th)] overflow-y-hidden`}>
         <Navbar />
-        <main className="pt-[var(--header-height)] h-[calc(100vh-var(--header-height))] overflow-y-auto scroll-smooth scroll-pt-[var(--header-height)]">
+        <main className="pt-[var(--header-height)] h-[calc(100dvh-var(--header-height))] overflow-y-auto scroll-smooth scroll-pt-[var(--header-height)]">
           {children}
           <Footer />
         </main>

--- a/src/app/under-construction/page.tsx
+++ b/src/app/under-construction/page.tsx
@@ -29,7 +29,7 @@ function UnderConstructionContent() {
   const isMobile = useIsMobile()
 
   return (
-    <div className="relative min-h-[100vh] flex items-center justify-center text-center px-6 bg-white snap-start transition-all">
+    <div className="relative min-h-[100dvh] flex items-center justify-center text-center px-6 bg-white snap-start transition-all">
       <div className="max-w-xl flex flex-col items-center">
         {/* ไอคอน 🚧 */}
         <div className="text-[80px] sm:text-[100px] leading-none mb-6">🚧</div>

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -9,7 +9,7 @@ export default function AboutSection() {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
-    <section className="relative min-h-[calc(100vh-var(--header-height))] snap-start bg-[#FFFEFE] px-4 py-16 lg:py-0 flex items-center justify-center">
+    <section className="relative min-h-[calc(100dvh-var(--header-height))] snap-start bg-[#FFFEFE] px-4 py-16 lg:py-0 flex items-center justify-center">
       <div className="max-w-7xl w-full mx-auto flex flex-col lg:flex-row items-center justify-center gap-12 mt-6 lg:mt-12">
         {/* Left (Text Content) */}
         <motion.div

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -8,7 +8,7 @@ export default function HeroSection() {
   return (
     <section
       id="herosection"
-      className="relative min-h-[calc(100vh-var(--header-height))] lg:pt-25 flex items-center justify-center text-center px-6 bg-[#FFFEFE] snap-start"
+      className="relative min-h-[calc(100dvh-var(--header-height))] lg:pt-25 flex items-center justify-center text-center px-6 bg-[#FFFEFE] snap-start"
     >
       {/* Background image */}
       <div className="absolute inset-0 z-0 bg-[url('/bg-hero.png')] bg-cover bg-center opacity-15"></div>

--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -59,7 +59,7 @@ export default function HowItWorksSection() {
   }, [hasStartedHighlight])
 
   return (
-    <section className="relative min-h-[calc(100vh-var(--header-height))] snap-start bg-[#fff4f4] flex flex-col justify-center px-4 py-30 md:py-50 lg:py-42">
+    <section className="relative min-h-[calc(100dvh-var(--header-height))] snap-start bg-[#fff4f4] flex flex-col justify-center px-4 py-30 md:py-50 lg:py-42">
       <div className="max-w-6xl mx-auto w-full flex flex-col justify-center">
         <h2 className="text-center text-2xl lg:text-4xl font-bold text-[#A70909] mb-16">ขั้นตอนการใช้บริการ</h2>
 

--- a/src/components/PopularServices.tsx
+++ b/src/components/PopularServices.tsx
@@ -41,7 +41,7 @@ export default function PopularServices() {
   const [hoverIndex, setHoverIndex] = useState<number | null>(null)
 
   return (
-    <section className="relative min-h-[calc(100vh-var(--header-height))] snap-start px-4 pt-[80px] sm:pt-[80px] lg:pt-25 pb-10 flex items-center justify-center bg-[#FFFEFE]">
+    <section className="relative min-h-[calc(100dvh-var(--header-height))] snap-start px-4 pt-[80px] sm:pt-[80px] lg:pt-25 pb-10 flex items-center justify-center bg-[#FFFEFE]">
       <div className="w-full max-w-7xl mx-auto">
         <h2 className="text-2xl lg:text-4xl font-bold text-center text-[#A70909] mb-10">บริการยอดนิยม</h2>
 

--- a/src/components/PromotionSection.tsx
+++ b/src/components/PromotionSection.tsx
@@ -25,7 +25,7 @@ export default function PromotionSection({
     const isImageLeft = imagePosition === 'left'
 
     return (
-        <section className="relative min-h-[calc(100vh-var(--header-height))] snap-start bg-[#FFFEFE] px-4 py-16 lg:py-0 flex items-center justify-center">
+        <section className="relative min-h-[calc(100dvh-var(--header-height))] snap-start bg-[#FFFEFE] px-4 py-16 lg:py-0 flex items-center justify-center">
             <div className={`max-w-7xl w-full mx-auto flex flex-col lg:flex-row items-center justify-center gap-12 mt-6 lg:mt-12`}>
                 {/* 🖼️ Image */}
                 <motion.div

--- a/src/components/WhyChooseUsSection.tsx
+++ b/src/components/WhyChooseUsSection.tsx
@@ -32,7 +32,7 @@ const features = [
 
 export default function WhyChooseUsSection() {
   return (
-    <section className="relative min-h-[calc(100vh-var(--header-height))] snap-start overflow-hidden px-4 py-40 md:py-58 lg:py-50">
+    <section className="relative min-h-[calc(100dvh-var(--header-height))] snap-start overflow-hidden px-4 py-40 md:py-58 lg:py-50">
       <motion.div
         className="absolute inset-0 z-0"
         initial={{ backgroundPosition: '100% 100%' }}


### PR DESCRIPTION
## Summary
- avoid 100vh issues on mobile by switching to `100dvh` in layout and sections

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font during build)*

------
https://chatgpt.com/codex/tasks/task_e_6849dda009488330a948fd453b45261f