### PR TITLE
Simplify ContactCTA transitions

### DIFF
--- a/src/components/ContactCTA.tsx
+++ b/src/components/ContactCTA.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useRef, useEffect } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
+// Framer Motion was replaced with simple CSS transitions for smoother mobile performance
 import { FaPhoneAlt, FaLine } from 'react-icons/fa'
 
 type ContactCTAProps = {
@@ -10,7 +10,6 @@ type ContactCTAProps = {
 
 export default function ContactCTA({ onExpandChange }: ContactCTAProps) {
   const [isOpen, setIsOpen] = useState(false)
-  const [isMobile, setIsMobile] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -23,12 +22,6 @@ export default function ContactCTA({ onExpandChange }: ContactCTAProps) {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  useEffect(() => {
-    const check = () => setIsMobile(window.innerWidth < 640)
-    check()
-    window.addEventListener('resize', check)
-    return () => window.removeEventListener('resize', check)
-  }, [])
 
   // ✅ แจ้งผลหลัง state เปลี่ยน
   useEffect(() => {
@@ -37,71 +30,30 @@ export default function ContactCTA({ onExpandChange }: ContactCTAProps) {
 
   return (
     <div className="relative h-12 w-full flex justify-center items-center" ref={containerRef}>
-      <AnimatePresence initial={false}>
-        {isOpen ? (
-          isMobile ? (
-            <motion.div
-              key="cta-options-mobile"
-                className="absolute top-0 flex flex-col items-center gap-3"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.2, ease: 'easeOut' }}
-              >
-                <a
-                  href="tel:0928825556"
-                  className="flex items-center justify-center gap-2 px-4 h-10 border-2 border-[#A70909] rounded-full text-[#A70909] font-medium text-sm hover:bg-[#A70909] hover:text-white transition-all duration-200 w-[190px]"
-                >
-                  <FaPhoneAlt className="text-base" /> โทร 092-882-5556
-                </a>
-                <a
-                  href="https://lin.ee/TBe5njP"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center justify-center h-10 px-4 rounded-full bg-[#06C755] text-white text-sm font-medium transition-all duration-200 hover:brightness-110 w-[190px]"
-                >
-                  <FaLine className="text-2xl mr-2" /> แชทเลย!
-                </a>
-              </motion.div>
-            ) : (
-              <motion.div
-                key="cta-options-desktop"
-                className="absolute inset-0 flex gap-4 justify-center items-center"
-                initial={{ opacity: 0, scale: 0.9 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0, scale: 0.9 }}
-                transition={{ duration: 0.4, ease: 'easeOut' }}
-              >
-                <a
-                  href="tel:0928825556"
-                  className="flex items-center gap-2 px-4 h-10 border-2 border-[#A70909] rounded-full text-[#A70909] font-medium text-sm hover:bg-[#A70909] hover:text-white transition w-[190px] justify-center"
-                >
-                  <FaPhoneAlt className="text-base" /> โทร 092-882-5556
-                </a>
-                <a
-                  href="https://lin.ee/TBe5njP"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center justify-center h-10 px-4 rounded-full bg-[#06C755] text-white text-sm font-medium transition hover:brightness-110 w-[190px]"
-                >
-                  <FaLine className="text-2xl mr-2" /> แชทเลย!
-                </a>
-              </motion.div>
-            )
-        ) : (
-          <motion.button
-            key="cta-main"
-            className="px-6 py-2 text-white bg-[#A70909] rounded-full text-base font-medium hover:bg-[#C9341F] transition"
-            onClick={() => setIsOpen(true)}
-            initial={{ opacity: 0, scale: 0.95 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.95 }}
-            transition={{ duration: 0.2 }}
-          >
-            ขอคำปรึกษาฟรี
-          </motion.button>
-        )}
-      </AnimatePresence>
+      <div
+        className={`absolute top-0 sm:inset-0 flex flex-col sm:flex-row items-center gap-3 sm:gap-4 transition-all duration-300 ${isOpen ? 'opacity-100 scale-100 pointer-events-auto' : 'opacity-0 scale-95 pointer-events-none'}`}
+      >
+        <a
+          href="tel:0928825556"
+          className="flex items-center justify-center gap-2 px-4 h-10 border-2 border-[#A70909] rounded-full text-[#A70909] font-medium text-sm hover:bg-[#A70909] hover:text-white transition-all duration-200 w-[190px]"
+        >
+          <FaPhoneAlt className="text-base" /> โทร 092-882-5556
+        </a>
+        <a
+          href="https://lin.ee/TBe5njP"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center justify-center h-10 px-4 rounded-full bg-[#06C755] text-white text-sm font-medium transition-all duration-200 hover:brightness-110 w-[190px]"
+        >
+          <FaLine className="text-2xl mr-2" /> แชทเลย!
+        </a>
+      </div>
+      <button
+        className={`px-6 py-2 text-white bg-[#A70909] rounded-full text-base font-medium hover:bg-[#C9341F] transition transform ${isOpen ? 'opacity-0 scale-95 pointer-events-none' : 'opacity-100 scale-100'}`}
+        onClick={() => setIsOpen(true)}
+      >
+        ขอคำปรึกษาฟรี
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- refactor ContactCTA to keep button group mounted
- replace Framer Motion exit/enter with CSS transitions

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6849dfb1e5488330adee380be1a6c8d9