### PR TITLE
Fix main layout height

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -82,7 +82,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className={`${fontTH.variable} ${fontEN.variable} font-[var(--font-th)] overflow-y-hidden`}>
         <Navbar />
-        <main className="pt-[var(--header-height)] h-[calc(100dvh-var(--header-height))] overflow-y-auto scroll-smooth scroll-pt-[var(--header-height)]">
+        <main className="pt-[var(--header-height)] h-[calc(100dvh-var(--header-height))] box-content overflow-y-auto scroll-smooth scroll-pt-[var(--header-height)]">
           {children}
           <Footer />
         </main>


### PR DESCRIPTION
## Summary
- fix bottom gap by setting main container box-sizing to content box

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849db4ac15883309ff85aa662c4284d