### PR TITLE
Fix body overflow to remove horizontal scrollbars

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -80,9 +80,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <StructuredData />
       </head>
-      <body className={`${fontTH.variable} ${fontEN.variable} font-[var(--font-th)] overflow-y-hidden`}>
+      <body className={`${fontTH.variable} ${fontEN.variable} font-[var(--font-th)] overflow-x-hidden overflow-y-hidden`}>
         <Navbar />
-        <main className="pt-[var(--header-height)] h-[calc(100dvh-var(--header-height))] box-content overflow-y-auto scroll-smooth scroll-pt-[var(--header-height)]">
+        <main className="pt-[var(--header-height)] h-[calc(100dvh-var(--header-height))] box-content overflow-y-auto overflow-x-hidden scroll-smooth scroll-pt-[var(--header-height)]">
           {children}
           <Footer />
         </main>


### PR DESCRIPTION
## Summary
- avoid horizontal scrolling by updating the body classes in layout
- also hide overflow on the main scroll container

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a781830608330a82535e367bb2a20