### PR TITLE
Fix horizontal scroll on mobile by hiding overflow

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -76,13 +76,13 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="th">
+    <html lang="th" className="overflow-x-hidden">
       <head>
         <StructuredData />
       </head>
-      <body className={`${fontTH.variable} ${fontEN.variable} font-[var(--font-th)] overflow-y-hidden`}>
+      <body className={`${fontTH.variable} ${fontEN.variable} font-[var(--font-th)] overflow-x-hidden overflow-y-hidden`}>
         <Navbar />
-        <main className="pt-[var(--header-height)] h-[calc(100dvh-var(--header-height))] box-content overflow-y-auto scroll-smooth scroll-pt-[var(--header-height)]">
+        <main className="pt-[var(--header-height)] h-[calc(100dvh-var(--header-height))] box-content overflow-y-auto overflow-x-hidden scroll-smooth scroll-pt-[var(--header-height)]">
           {children}
           <Footer />
         </main>


### PR DESCRIPTION
## Summary
- also hide overflow at the `<html>` level

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a781830608330a82535e367bb2a20