### PR TITLE
Remove transition-all from PopularServices cards

### DIFF
--- a/src/components/PopularServices.tsx
+++ b/src/components/PopularServices.tsx
@@ -55,7 +55,7 @@ export default function PopularServices() {
                 <motion.div
                   onMouseEnter={() => setHoverIndex(index)}
                   onMouseLeave={() => setHoverIndex(null)}
-                  className={`relative rounded-xl overflow-hidden bg-white shadow-md group transition-all duration-300
+                  className={`relative rounded-xl overflow-hidden bg-white shadow-md group duration-300
                     ${index === 0
                       ? 'sm:col-span-2 sm:row-span-1 lg:col-span-2 lg:row-span-2'
                       : 'sm:col-span-1 sm:row-span-1 lg:col-span-1 lg:row-span-1'}


### PR DESCRIPTION
## Summary
- update PopularServices card container class to remove `transition-all`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a93edf0988330b39e3ffa07ad1553