### PR TITLE
Improve image loading

### DIFF
--- a/src/components/PopularServices.tsx
+++ b/src/components/PopularServices.tsx
@@ -73,7 +73,9 @@ export default function PopularServices() {
                     fill
                     sizes={index === 0 ? '(min-width: 1024px) 50vw, (min-width: 640px) 50vw, 100vw' : '(min-width: 1024px) 25vw, (min-width: 640px) 50vw, 100vw'}
                     priority={index < 2}
-                    className="absolute inset-0 object-cover object-center opacity-80 group-hover:opacity-100 transition duration-300"
+                    placeholder="empty"
+                    onLoadingComplete={(img) => img.classList.remove('opacity-0')}
+                    className="absolute inset-0 object-cover object-center opacity-80 group-hover:opacity-100 transition-opacity duration-300 opacity-0"
                   />
 
                   <div className="absolute bottom-0 left-0 right-0 bg-white bg-opacity-90 px-4 py-3 z-10">


### PR DESCRIPTION
## Summary
- fade in service images on load by using `onLoadingComplete`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a98bd102c833086034706e44cf96b