### PR TITLE
Remove custom image fade to prevent flicker

### DIFF
--- a/src/components/PopularServices.tsx
+++ b/src/components/PopularServices.tsx
@@ -73,9 +73,7 @@ export default function PopularServices() {
                     fill
                     sizes={index === 0 ? '(min-width: 1024px) 50vw, (min-width: 640px) 50vw, 100vw' : '(min-width: 1024px) 25vw, (min-width: 640px) 50vw, 100vw'}
                     priority={index < 2}
-                    placeholder="empty"
-                    onLoadingComplete={(img) => img.classList.remove('opacity-0')}
-                    className="absolute inset-0 object-cover object-center opacity-80 group-hover:opacity-100 transition-opacity duration-300 opacity-0"
+                    className="absolute inset-0 object-cover object-center opacity-80 group-hover:opacity-100 transition-opacity duration-300"
                   />
 
                   <div className="absolute bottom-0 left-0 right-0 bg-white bg-opacity-90 px-4 py-3 z-10">


### PR DESCRIPTION
## Summary
- avoid manipulating opacity in `PopularServices` images

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a9a97289083308250a1e31965ec4c