### PR TITLE
Add no-image-fade utility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,3 +28,8 @@ body {
 .text-shadow-white {
   text-shadow: 0 2px 6px rgba(255, 255, 255, 0.5);
 }
+
+.no-image-fade {
+  animation: none !important;
+  transition: none !important;
+}

--- a/src/components/PopularServices.tsx
+++ b/src/components/PopularServices.tsx
@@ -73,7 +73,7 @@ export default function PopularServices() {
                     fill
                     sizes={index === 0 ? '(min-width: 1024px) 50vw, (min-width: 640px) 50vw, 100vw' : '(min-width: 1024px) 25vw, (min-width: 640px) 50vw, 100vw'}
                     priority={index < 2}
-                    className="absolute inset-0 object-cover object-center opacity-80 group-hover:opacity-100"
+                    className="absolute inset-0 object-cover object-center opacity-80 group-hover:opacity-100 no-image-fade"
                   />
 
                   <div className="absolute bottom-0 left-0 right-0 bg-white bg-opacity-90 px-4 py-3 z-10">


### PR DESCRIPTION
## Summary
- add `.no-image-fade` utility in global CSS
- prevent fade/transition on service images using this new class

## Testing
- `npm run lint`
- `npm run dev` *(fails to confirm flicker removal due to no browser access)*

------
https://chatgpt.com/codex/tasks/task_e_684ae04b57348330b14d6ceab337c8a7