### PR TITLE
Fix popular services link layout

### DIFF
--- a/src/components/PopularServices.tsx
+++ b/src/components/PopularServices.tsx
@@ -52,7 +52,7 @@ export default function PopularServices() {
             const href = `/under-construction?section=บริการยอดนิยม&item=${encodeURIComponent(service.title)}`
 
             return (
-              <Link href={href} key={index} className="contents">
+              <Link href={href} key={index} className="block">
                 <motion.div
                   onMouseEnter={() => setHoverIndex(index)}
                   onMouseLeave={() => setHoverIndex(null)}


### PR DESCRIPTION
## Summary
- fix flicker issue in `PopularServices` by using `className="block"`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684aebfd3a8c8330b08a9227047b74c0