### PR TITLE
Add ScrollToHero component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { Suspense } from 'react'
-import { useSearchParams } from 'next/navigation'
-import { useEffect } from 'react'
+import ScrollToHero from '@/components/ScrollToHero'
 import HeroSection from '@/components/HeroSection'
 import PopularServices from '@/components/PopularServices'
 import AboutSection from '@/components/AboutSection'
@@ -10,29 +9,9 @@ import WhyChooseUsSection from '@/components/WhyChooseUsSection'
 import HowItWorksSection from '@/components/HowItWorksSection'
 
 function HomePageContent() {
-  const searchParams = useSearchParams()
-
-  useEffect(() => {
-    const shouldScroll = searchParams.get('scrollToHero') === 'true'
-    if (shouldScroll) {
-      const timeout = setTimeout(() => {
-        const target = document.getElementById('herosection')
-        if (target) {
-          target.scrollIntoView({ behavior: 'smooth' })
-
-          // ลบ query ออกเพื่อไม่ scroll ซ้ำอีก
-          const url = new URL(window.location.href)
-          url.searchParams.delete('scrollToHero')
-          window.history.replaceState({}, '', url.toString())
-        }
-      }, 50)
-
-      return () => clearTimeout(timeout)
-    }
-  }, [searchParams])
-
   return (
     <>
+      <ScrollToHero />
       <HeroSection />
       <PopularServices />
       <AboutSection />

--- a/src/components/ScrollToHero.tsx
+++ b/src/components/ScrollToHero.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+export default function ScrollToHero() {
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const shouldScroll = searchParams.get('scrollToHero') === 'true'
+    if (shouldScroll) {
+      const timeout = setTimeout(() => {
+        const target = document.getElementById('herosection')
+        if (target) {
+          target.scrollIntoView({ behavior: 'smooth' })
+
+          const url = new URL(window.location.href)
+          url.searchParams.delete('scrollToHero')
+          window.history.replaceState({}, '', url.toString())
+        }
+      }, 50)
+
+      return () => clearTimeout(timeout)
+    }
+  }, [searchParams])
+
+  return null
+}


### PR DESCRIPTION
## Summary
- implement new `ScrollToHero` component to scroll to the hero section
  and remove the `scrollToHero` query parameter after scrolling
- refactor homepage to use the new component

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b290e704c83308018fae1fcdd3439