### PR TITLE
Refactor root layout scroll handling

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Navbar from '@/components/navbar/Navbar'
 import StructuredData from '@/components/StructuredData'
 import type { Metadata } from 'next'
 import Footer from '@/components/Footer'
+import ScrollRestoration from '@/components/ScrollRestoration'
 
 const fontTH = Prompt({
   subsets: ['thai'],
@@ -82,7 +83,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className={`${fontTH.variable} ${fontEN.variable} font-[var(--font-th)] overflow-x-hidden overflow-y-hidden`}>
         <Navbar />
-        <main className="pt-[var(--header-height)] h-[calc(100dvh-var(--header-height))] box-content overflow-y-auto overflow-x-hidden scroll-smooth scroll-pt-[var(--header-height)]">
+        <ScrollRestoration />
+        <main
+          id="main"
+          className="pt-[var(--header-height)] h-[calc(100dvh-var(--header-height))] box-content overflow-y-auto overflow-x-hidden scroll-smooth scroll-pt-[var(--header-height)]"
+        >
           {children}
           <Footer />
         </main>

--- a/src/components/ScrollRestoration.tsx
+++ b/src/components/ScrollRestoration.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useLayoutEffect } from 'react'
+import { usePathname } from 'next/navigation'
+
+export default function ScrollRestoration() {
+  const pathname = usePathname()
+
+  useLayoutEffect(() => {
+    if ('scrollRestoration' in window.history) {
+      window.history.scrollRestoration = 'manual'
+    }
+    const main = document.getElementById('main')
+    if (main) {
+      main.scrollTo(0, 0)
+    } else {
+      window.scrollTo(0, 0)
+    }
+  }, [pathname])
+
+  return null
+}


### PR DESCRIPTION
## Summary
- move scroll restoration effect to a new client component
- give `<main>` an id and mount ScrollRestoration in the layout

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684b966837c88330a142425fee6d6fdc