### PR TITLE
Fix footer flicker on reload

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -80,6 +80,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="th">
       <head>
         <StructuredData />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `if ('scrollRestoration' in history) { history.scrollRestoration = 'manual'; }`,
+          }}
+        />
       </head>
       <body className={`${fontTH.variable} ${fontEN.variable} font-[var(--font-th)] overflow-x-hidden overflow-y-hidden`}>
         <Navbar />


### PR DESCRIPTION
## Summary
- prevent initial scroll restoration by injecting a script in the root layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b9926e81083309f195e17faeaa889