### PR TITLE
Fix scroll restoration script

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -82,7 +82,16 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <StructuredData />
         <script
           dangerouslySetInnerHTML={{
-            __html: `if ('scrollRestoration' in history) { history.scrollRestoration = 'manual'; }`,
+            __html: `
+          if ('scrollRestoration' in history) {
+            history.scrollRestoration = 'manual'
+          }
+          window.addEventListener('DOMContentLoaded', () => {
+            const main = document.getElementById('main')
+            if (main) main.scrollTo(0, 0)
+            else window.scrollTo(0, 0)
+          })
+        `,
           }}
         />
       </head>

--- a/src/components/ScrollRestoration.tsx
+++ b/src/components/ScrollRestoration.tsx
@@ -1,22 +1,13 @@
 'use client'
 
 import { useLayoutEffect } from 'react'
-import { usePathname } from 'next/navigation'
 
 export default function ScrollRestoration() {
-  const pathname = usePathname()
-
   useLayoutEffect(() => {
     if ('scrollRestoration' in window.history) {
       window.history.scrollRestoration = 'manual'
     }
-    const main = document.getElementById('main')
-    if (main) {
-      main.scrollTo(0, 0)
-    } else {
-      window.scrollTo(0, 0)
-    }
-  }, [pathname])
+  }, [])
 
   return null
 }


### PR DESCRIPTION
## Summary
- scroll to the top on DOMContentLoaded
- simplify scroll restoration logic

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`: https://fonts.googleapis.com/css2...)*

------
https://chatgpt.com/codex/tasks/task_e_684b9d61a32483308a114205aef77d00