### PR TITLE
Fix home page without suspense wrapper

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
-'use client'
 
-import { Suspense } from 'react'
+
 import ScrollToHero from '@/components/ScrollToHero'
 import HeroSection from '@/components/HeroSection'
 import PopularServices from '@/components/PopularServices'
@@ -22,9 +21,5 @@ function HomePageContent() {
 }
 
 export default function HomePage() {
-  return (
-    <Suspense fallback={null}>
-      <HomePageContent />
-    </Suspense>
-  )
+  return <HomePageContent />
 }


### PR DESCRIPTION
## Summary
- clean up `page.tsx` by removing the `use client` directive and `<Suspense>` wrapper

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*


------
https://chatgpt.com/codex/tasks/task_e_684c247d56f48330b9c79e38a290d5f7