### PR TITLE
Fix initial scroll jump on homepage

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -86,8 +86,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               history.scrollRestoration = 'manual'
             }
             const main = document.getElementById('main')
-            if (main) main.scrollTo(0, 0)
-            else window.scrollTo(0, 0)
+            if (main) {
+              main.scrollTo({ top: 0, left: 0, behavior: 'auto' })
+            } else {
+              window.scrollTo({ top: 0, left: 0, behavior: 'auto' })
+            }
           `}
         </Script>
       </head>


### PR DESCRIPTION
## Summary
- disable smooth scrolling during scroll-restoration script

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Prompt` and `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684c2c44247083309db6a3a5b2a0dd48