### PR TITLE
Fix footer flicker by inlining section height styles

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -79,6 +79,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="th">
       <head>
+        <style>{`:root{--header-height:72px;}`}</style>
         <StructuredData />
         <Script id="scroll-restoration" strategy="beforeInteractive">
           {`
@@ -98,6 +99,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Navbar />
         <main
           id="main"
+          style={{
+            paddingTop: 'var(--header-height)',
+            height: 'calc(100dvh - var(--header-height))',
+          }}
           className="pt-[var(--header-height)] h-[calc(100dvh-var(--header-height))] box-content overflow-y-auto overflow-x-hidden scroll-smooth scroll-pt-[var(--header-height)]"
         >
           {children}

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -9,7 +9,10 @@ export default function AboutSection() {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
-    <section className="relative min-h-[calc(100dvh-var(--header-height))] snap-start bg-[#FFFEFE] px-4 py-16 lg:py-0 flex items-center justify-center">
+    <section
+      className="relative min-h-[calc(100dvh-var(--header-height))] snap-start bg-[#FFFEFE] px-4 py-16 lg:py-0 flex items-center justify-center"
+      style={{ minHeight: 'calc(100dvh - var(--header-height))' }}
+    >
       <div className="max-w-7xl w-full mx-auto flex flex-col lg:flex-row items-center justify-center gap-12 mt-6 lg:mt-12">
         {/* Left (Text Content) */}
         <motion.div

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -8,6 +8,7 @@ export default function HeroSection() {
   return (
     <section
       id="herosection"
+      style={{ minHeight: 'calc(100dvh - var(--header-height))' }}
       className="relative min-h-[calc(100dvh-var(--header-height))] lg:pt-25 flex items-center justify-center text-center px-6 bg-[#FFFEFE] snap-start"
     >
       {/* Background image */}

--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -59,7 +59,10 @@ export default function HowItWorksSection() {
   }, [hasStartedHighlight])
 
   return (
-    <section className="relative min-h-[calc(100dvh-var(--header-height))] snap-start bg-[#fff4f4] flex flex-col justify-center px-4 py-30 md:py-50 lg:py-42">
+    <section
+      className="relative min-h-[calc(100dvh-var(--header-height))] snap-start bg-[#fff4f4] flex flex-col justify-center px-4 py-30 md:py-50 lg:py-42"
+      style={{ minHeight: 'calc(100dvh - var(--header-height))' }}
+    >
       <div className="max-w-6xl mx-auto w-full flex flex-col justify-center">
         <h2 className="text-center text-2xl lg:text-4xl font-bold text-[#A70909] mb-16">ขั้นตอนการใช้บริการ</h2>
 

--- a/src/components/PopularServices.tsx
+++ b/src/components/PopularServices.tsx
@@ -42,7 +42,10 @@ export default function PopularServices() {
   const [hoverIndex, setHoverIndex] = useState<number | null>(null)
 
   return (
-    <section className="relative min-h-[calc(100dvh-var(--header-height))] snap-start px-4 pt-[80px] sm:pt-[80px] lg:pt-25 pb-10 flex items-center justify-center bg-[#FFFEFE]">
+    <section
+      className="relative min-h-[calc(100dvh-var(--header-height))] snap-start px-4 pt-[80px] sm:pt-[80px] lg:pt-25 pb-10 flex items-center justify-center bg-[#FFFEFE]"
+      style={{ minHeight: 'calc(100dvh - var(--header-height))' }}
+    >
       <div className="w-full max-w-7xl mx-auto">
         <h2 className="text-2xl lg:text-4xl font-bold text-center text-[#A70909] mb-10">บริการยอดนิยม</h2>
 

--- a/src/components/PromotionSection.tsx
+++ b/src/components/PromotionSection.tsx
@@ -25,7 +25,10 @@ export default function PromotionSection({
     const isImageLeft = imagePosition === 'left'
 
     return (
-        <section className="relative min-h-[calc(100dvh-var(--header-height))] snap-start bg-[#FFFEFE] px-4 py-16 lg:py-0 flex items-center justify-center">
+        <section
+            className="relative min-h-[calc(100dvh-var(--header-height))] snap-start bg-[#FFFEFE] px-4 py-16 lg:py-0 flex items-center justify-center"
+            style={{ minHeight: 'calc(100dvh - var(--header-height))' }}
+        >
             <div className={`max-w-7xl w-full mx-auto flex flex-col lg:flex-row items-center justify-center gap-12 mt-6 lg:mt-12`}>
                 {/* 🖼️ Image */}
                 <motion.div

--- a/src/components/WhyChooseUsSection.tsx
+++ b/src/components/WhyChooseUsSection.tsx
@@ -32,7 +32,10 @@ const features = [
 
 export default function WhyChooseUsSection() {
   return (
-    <section className="relative min-h-[calc(100dvh-var(--header-height))] snap-start overflow-hidden px-4 py-40 md:py-58 lg:py-50">
+    <section
+      className="relative min-h-[calc(100dvh-var(--header-height))] snap-start overflow-hidden px-4 py-40 md:py-58 lg:py-50"
+      style={{ minHeight: 'calc(100dvh - var(--header-height))' }}
+    >
       <motion.div
         className="absolute inset-0 z-0"
         initial={{ backgroundPosition: '100% 100%' }}


### PR DESCRIPTION
## Summary
- add inline styles to `<main>` and hero sections to preserve layout before Tailwind loads

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c31b61cc88330a22515c5388da8de