### PR TITLE
Remove useSearchParams usage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-// Using React Suspense to handle asynchronous components on the homepage
-import { Suspense } from 'react'
+// Using React components on the homepage without Suspense
 import ScrollToHero from '@/components/ScrollToHero'
 import HeroSection from '@/components/HeroSection'
 import PopularServices from '@/components/PopularServices'
@@ -23,9 +22,5 @@ function HomePageContent() {
 }
 
 export default function HomePage() {
-  return (
-    <Suspense fallback={null}>
-      <HomePageContent />
-    </Suspense>
-  )
+  return <HomePageContent />
 }

--- a/src/app/under-construction/page.tsx
+++ b/src/app/under-construction/page.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { Suspense } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
 import ContactCTA from '@/components/ContactCTA'
 import BorderRevealButton from '@/components/BorderRevealButton'
-import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 
 function useIsMobile() {
@@ -21,9 +19,14 @@ function useIsMobile() {
 }
 
 function UnderConstructionContent() {
-  const searchParams = useSearchParams()
-  const section = searchParams.get('section') || 'หมวดหมู่ไม่ระบุ'
-  const item = searchParams.get('item') || 'หัวข้อไม่ระบุ'
+  const [section, setSection] = useState('หมวดหมู่ไม่ระบุ')
+  const [item, setItem] = useState('หัวข้อไม่ระบุ')
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    setSection(params.get('section') || 'หมวดหมู่ไม่ระบุ')
+    setItem(params.get('item') || 'หัวข้อไม่ระบุ')
+  }, [])
 
   const [ctaExpanded, setCtaExpanded] = useState(false)
   const isMobile = useIsMobile()
@@ -63,9 +66,5 @@ function UnderConstructionContent() {
 }
 
 export default function UnderConstructionPage() {
-  return (
-    <Suspense fallback={null}>
-      <UnderConstructionContent />
-    </Suspense>
-  )
+  return <UnderConstructionContent />
 }

--- a/src/components/ScrollToHero.tsx
+++ b/src/components/ScrollToHero.tsx
@@ -1,13 +1,11 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useSearchParams } from 'next/navigation'
 
 export default function ScrollToHero() {
-  const searchParams = useSearchParams()
-
   useEffect(() => {
-    const shouldScroll = searchParams.get('scrollToHero') === 'true'
+    const params = new URLSearchParams(window.location.search)
+    const shouldScroll = params.get('scrollToHero') === 'true'
     if (shouldScroll) {
       const timeout = setTimeout(() => {
         const target = document.getElementById('herosection')
@@ -22,7 +20,7 @@ export default function ScrollToHero() {
 
       return () => clearTimeout(timeout)
     }
-  }, [searchParams])
+  }, [])
 
   return null
 }


### PR DESCRIPTION
## Summary
- drop useSearchParams and grab search params from the window object
- keep client components simple by removing Suspense wrappers

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684c3a5a3a84833097dc61dc707fd3f9