### PR TITLE
Add canonical metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,6 +73,9 @@ export const metadata: Metadata = {
     apple: '/apple-icon.png',
   },
   manifest: '/manifest.json',
+  alternates: {
+    canonical: 'https://virintira.com/',
+  },
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,15 @@ import PopularServices from '@/components/PopularServices'
 import AboutSection from '@/components/AboutSection'
 import WhyChooseUsSection from '@/components/WhyChooseUsSection'
 import HowItWorksSection from '@/components/HowItWorksSection'
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    alternates: {
+      canonical: 'https://virintira.com/',
+    },
+  }
+}
 
 function HomePageContent() {
   return (

--- a/src/app/promotion/page.tsx
+++ b/src/app/promotion/page.tsx
@@ -1,6 +1,15 @@
 'use client'
 
 import PromotionSection from '@/components/PromotionSection'
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    alternates: {
+      canonical: 'https://virintira.com/promotion',
+    },
+  }
+}
 
 export default function PromotionPage() {
   return (

--- a/src/app/under-construction/page.tsx
+++ b/src/app/under-construction/page.tsx
@@ -4,6 +4,15 @@ import { useEffect, useState } from 'react'
 import ContactCTA from '@/components/ContactCTA'
 import BorderRevealButton from '@/components/BorderRevealButton'
 import { motion } from 'framer-motion'
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    alternates: {
+      canonical: 'https://virintira.com/under-construction',
+    },
+  }
+}
 
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(false)


### PR DESCRIPTION
## Summary
- add canonical tags to root layout and pages
- include metadata on each page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c4f98a9188330b82bb4916a49d50a