### PR TITLE
Add canonical metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,6 +21,7 @@ const fontEN = Inter({
 export const metadata: Metadata = {
   title: 'สำนักงานบัญชี VIRINTIRA | สำนักงานบัญชีและบริหารธุรกิจครบวงจร',
   description: 'ให้บริการบัญชี ภาษี จดทะเบียนธุรกิจ และการตลาดออนไลน์',
+  alternates: { canonical: 'https://virintira.com' },
   keywords: [
     'สำนักงานบัญชี',
     'บริการบัญชี',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,11 @@ import PopularServices from '@/components/PopularServices'
 import AboutSection from '@/components/AboutSection'
 import WhyChooseUsSection from '@/components/WhyChooseUsSection'
 import HowItWorksSection from '@/components/HowItWorksSection'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  alternates: { canonical: 'https://virintira.com' },
+}
 
 function HomePageContent() {
   return (

--- a/src/app/promotion/page.tsx
+++ b/src/app/promotion/page.tsx
@@ -1,4 +1,9 @@
 import PromotionSection from '@/components/PromotionSection'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  alternates: { canonical: 'https://virintira.com/promotion' },
+}
 
 export default function PromotionPage() {
   return (

--- a/src/app/under-construction/page.tsx
+++ b/src/app/under-construction/page.tsx
@@ -3,6 +3,7 @@ import UnderConstructionContent from './UnderConstructionContent'
 
 export const generateMetadata = (): Metadata => ({
   title: 'หน้ากำลังพัฒนา',
+  alternates: { canonical: 'https://virintira.com/under-construction' },
 })
 
 export default function UnderConstructionPage() {


### PR DESCRIPTION
## Summary
- specify canonical `alternates` in root layout
- add canonical metadata for home, promotion, and under-construction pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c58cd3e988330af1fb720cc3c772e