### PR TITLE
Update hero section navigation

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import {
   FaPhoneAlt,
   FaLine,
@@ -13,16 +13,12 @@ import {
 
 export default function Footer() {
   const pathname = usePathname()
+  const router = useRouter()
   const handleLogoClick = () => {
     if (pathname === '/') {
-      const target = document.getElementById('herosection')
-      if (target) {
-        target.scrollIntoView({ behavior: 'smooth' })
-      } else {
-        window.scrollTo({ top: 0, behavior: 'smooth' })
-      }
+      window.location.hash = 'herosection'
     } else {
-      window.location.href = '/?scrollToHero=true'
+      router.push('/#herosection')
     }
   }
 

--- a/src/components/ScrollToHero.tsx
+++ b/src/components/ScrollToHero.tsx
@@ -4,21 +4,26 @@ import { useEffect } from 'react'
 
 export default function ScrollToHero() {
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    const shouldScroll = params.get('scrollToHero') === 'true'
-    if (shouldScroll) {
-      const timeout = setTimeout(() => {
-        const target = document.getElementById('herosection')
-        if (target) {
-          target.scrollIntoView({ behavior: 'smooth' })
+    let timeout: ReturnType<typeof setTimeout> | null = null
 
-          const url = new URL(window.location.href)
-          url.searchParams.delete('scrollToHero')
-          window.history.replaceState({}, '', url.toString())
-        }
-      }, 50)
+    const handleHashChange = () => {
+      if (window.location.hash === '#herosection') {
+        if (timeout) clearTimeout(timeout)
+        timeout = setTimeout(() => {
+          const target = document.getElementById('herosection')
+          if (target) {
+            target.scrollIntoView({ behavior: 'smooth' })
+          }
+        }, 50)
+      }
+    }
 
-      return () => clearTimeout(timeout)
+    handleHashChange()
+    window.addEventListener('hashchange', handleHashChange)
+
+    return () => {
+      if (timeout) clearTimeout(timeout)
+      window.removeEventListener('hashchange', handleHashChange)
     }
   }, [])
 

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -8,7 +8,7 @@ import {
   useCallback,
   useLayoutEffect,
 } from 'react'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import MegaMenu from './MegaMenu'
 import LanguageSwitcher from './LanguageSwitcher'
 import HamburgerButton from './HamburgerButton'
@@ -23,6 +23,7 @@ export default function Navbar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const hideTimer = useRef<NodeJS.Timeout | null>(null)
   const pathname = usePathname()
+  const router = useRouter()
   const headerRef = useRef<HTMLElement | null>(null)
   const DEFAULT_HEADER_HEIGHT = 72
 
@@ -55,14 +56,9 @@ export default function Navbar() {
 
   const handleLogoClick = () => {
     if (pathname === '/') {
-      const target = document.getElementById('herosection')
-      if (target) {
-        target.scrollIntoView({ behavior: 'smooth' })
-      } else {
-        window.scrollTo({ top: 0, behavior: 'smooth' })
-      }
+      window.location.hash = 'herosection'
     } else {
-      window.location.href = '/?scrollToHero=true'
+      router.push('/#herosection')
     }
   }
 


### PR DESCRIPTION
## Summary
- use router push & hash navigation for logo click handlers
- scroll to hero section when hash changes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c5e4ad154833087061fac9b09e29a