### PR TITLE
Add redirect config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,25 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.virintira.com" }],
+        destination: "https://virintira.com/:path*",
+        permanent: true,
+      },
+      {
+        source: "/:path*",
+        has: [
+          { type: "host", value: "virintira.com" },
+          { type: "header", key: "x-forwarded-proto", value: "http" },
+        ],
+        destination: "https://virintira.com/:path*",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/server.js
+++ b/server.js
@@ -17,20 +17,11 @@ app.prepare().then(() => {
         ? protoHeader[0]
         : (protoHeader || '').split(',')[0].trim();
       const hostHeader = req.headers.host || '';
-      const host = hostHeader.split(':')[0];
 
       // Only redirect when the request actually used HTTP. An undefined header
       // may mean the proxy already handled HTTPS.
       if (proto === 'http') {
         res.writeHead(301, { Location: `https://${hostHeader}${req.url}` });
-        res.end();
-        return;
-      }
-
-      if (host.toLowerCase() === 'www.virintira.com') {
-        res.writeHead(301, {
-          Location: `https://virintira.com${req.url}`,
-        });
         res.end();
         return;
       }


### PR DESCRIPTION
## Summary
- handle HTTPS and domain redirects in `next.config.ts`
- simplify redirection logic in `server.js`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8f4ea7c88330bf79162c3406b9e8