### PR TITLE
Resolve duplicate HTTPS redirect logic

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,15 +9,6 @@ const nextConfig: NextConfig = {
         destination: "https://virintira.com/:path*",
         permanent: true,
       },
-      {
-        source: "/:path*",
-        has: [
-          { type: "host", value: "virintira.com" },
-          { type: "header", key: "x-forwarded-proto", value: "http" },
-        ],
-        destination: "https://virintira.com/:path*",
-        permanent: true,
-      },
     ];
   },
 };


### PR DESCRIPTION
## Summary
- keep HTTP→HTTPS redirect in `server.js`
- remove overlapping rule from `next.config.ts`

## Testing
- `npm install`
- `npx next lint`


------
https://chatgpt.com/codex/tasks/task_e_684c9557810c833088aaf971320df187