### PR TITLE
Normalize forwarding headers and relax HTTPS redirect check

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "NODE_ENV=production node server.js",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node test/mixed-header.test.js"
   },
   "dependencies": {
     "framer-motion": "^12.12.2",

--- a/test/mixed-header.test.js
+++ b/test/mixed-header.test.js
@@ -1,0 +1,6 @@
+const assert = require('assert');
+const { shouldRedirectToHttps } = require('../server');
+
+const req = { headers: { 'x-forwarded-proto': 'https,http' } };
+assert.strictEqual(shouldRedirectToHttps(req), false, 'should not redirect when header includes https');
+console.log('mixed-header test passed');


### PR DESCRIPTION
## Summary
- export helpers for forwarded proto handling in `server.js`
- detect protocol via `X-Forwarded-Proto` or `Forwarded`
- skip redirect when header contains `https`
- add basic test for mixed `https,http` header
- wire up npm test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c97022f088330af35f1450251819e