### PR TITLE
Add optional HTTPS redirect flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## HTTPS Redirect
+
+This project includes optional logic in `server.js` to force HTTPS. The redirect
+is controlled by the `ENABLE_SSL_REDIRECT` environment variable. Set it to
+`true` to enable the redirect in production or leave it unset to disable the
+behaviour (useful when running behind a proxy that already handles HTTPS).

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const next = require('next');
 
 const port = process.env.PORT || 3000;
 const dev = process.env.NODE_ENV !== 'production';
+const enableSslRedirect = process.env.ENABLE_SSL_REDIRECT === 'true';
 const app = next({ dev });
 const handle = app.getRequestHandler();
 
@@ -33,7 +34,7 @@ function shouldRedirectToHttps(req) {
 if (require.main === module) {
   app.prepare().then(() => {
     createServer((req, res) => {
-      if (!dev && shouldRedirectToHttps(req)) {
+      if (!dev && enableSslRedirect && shouldRedirectToHttps(req)) {
         const hostHeader = req.headers.host || '';
         res.writeHead(301, { Location: `https://${hostHeader}${req.url}` });
         res.end();


### PR DESCRIPTION
## Summary
- add `ENABLE_SSL_REDIRECT` toggle in `server.js`
- update redirect logic to check the flag
- document the new environment variable

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d16c676448330b4d1ccddd9cfafae