### PR TITLE
Update LanguageSwitcher import for next-intl

### DIFF
--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
 import { FaGlobe } from 'react-icons/fa'
+import {createLocalizedPathnamesNavigation} from 'next-intl/navigation'
+import {locales, localePrefix} from '../../i18n'
+const {useRouter, usePathname, useLocale} =
+  createLocalizedPathnamesNavigation({locales, localePrefix})
 
 export default function LanguageSwitcher() {
   const [dropdownOpen, setDropdownOpen] = useState(false)

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,5 @@
+export const locales = ['en', 'th'] as const
+export type Locale = (typeof locales)[number]
+
+export const localePrefix = undefined
+


### PR DESCRIPTION
## Summary
- use `createLocalizedPathnamesNavigation` for LanguageSwitcher
- define simple `i18n` config with locales and prefix

## Testing
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685386305c108330a19ff212bcc3a898