### PR TITLE
Fix promotion translations

### DIFF
--- a/src/app/[locale]/promotion/page.tsx
+++ b/src/app/[locale]/promotion/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 };
 
 export default function PromotionPage() {
-  const t = useTranslations('promotion');
+  const t = useTranslations();
   return (
     <main className="bg-[#FFFEFE]">
       <PromotionSection


### PR DESCRIPTION
## Summary
- remove promotion namespace argument in `useTranslations` call

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685932fe5cb48330a3cc92859acfd8bd