### PR TITLE
Fix language switcher imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "framer-motion": "^12.12.2",
         "next": "15.3.2",
-        "next-intl": "^4.1.0",
+        "next-intl": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
@@ -5236,9 +5236,9 @@
       }
     },
     "node_modules/next-intl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.1.0.tgz",
-      "integrity": "sha512-JNJRjc7sdnfUxhZmGcvzDszZ60tQKrygV/VLsgzXhnJDxQPn1cN2rVpc53adA1SvBJwPK2O6Sc6b4gYSILjCzw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.2.0.tgz",
+      "integrity": "sha512-+uuSazIDBbz/CMNzXGQGwX3sN2zjUOfgy/N7LkBkMHg5gkYd2mT0mzqueuPJkhp0hcMuYQ9nnKyjCcZ2Fzmv5Q==",
       "funding": [
         {
           "type": "individual",
@@ -5249,7 +5249,7 @@
       "dependencies": {
         "@formatjs/intl-localematcher": "^0.5.4",
         "negotiator": "^1.0.0",
-        "use-intl": "^4.1.0"
+        "use-intl": "^4.2.0"
       },
       "peerDependencies": {
         "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
@@ -7116,9 +7116,9 @@
       }
     },
     "node_modules/use-intl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.1.0.tgz",
-      "integrity": "sha512-mQvDYFvoGn+bm/PWvlQOtluKCknsQ5a9F1Cj0hMfBjMBVTwnOqLPd6srhjvVdEQEQFVyHM1PfyifKqKYb11M9Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.2.0.tgz",
+      "integrity": "sha512-lPxKSk2Fb3HdD6Q2UYSgR4rnCuaRwsi4MVJE7WIMjwmqHGgRcl2OcSYIZWdMCDZ3AOXBICl3buLfS5SwdHzMZg==",
       "license": "MIT",
       "dependencies": {
         "@formatjs/fast-memoize": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "framer-motion": "^12.12.2",
     "next": "15.3.2",
-    "next-intl": "^4.1.0",
+    "next-intl": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",

--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
 import { FaGlobe } from 'react-icons/fa'
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { Link, usePathname, useSearchParams } from 'next-intl/navigation'
 import { useLocale } from 'next-intl'
 import { locales, localeInfo } from '../../../i18n'
 
@@ -13,7 +13,6 @@ export default function LanguageSwitcher() {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const locale = useLocale()
-  const router = useRouter()
 
   const toggleDropdown = () => setDropdownOpen((prev) => !prev)
 
@@ -30,20 +29,8 @@ export default function LanguageSwitcher() {
     }
   }, [])
 
-  // สร้าง path สำหรับแต่ละ locale
-  const getLocalePath = (targetLocale: string) => {
-    // ลบ locale ปัจจุบันออกจาก pathname ด้วย regex
-    const pathWithoutLocale = pathname.replace(/^\/(th|en)/, '') || '/'
-    const query = searchParams.toString()
-    return `/${targetLocale}${pathWithoutLocale}${query ? `?${query}` : ''}`
-  }
-
-  const handleLanguageChange = (targetLocale: string) => {
-    setDropdownOpen(false)
-    const newPath = getLocalePath(targetLocale)
-    router.push(newPath)
-    router.refresh()
-  }
+  const query = searchParams.toString()
+  const href = `${pathname}${query ? `?${query}` : ''}`
 
   return (
     <div ref={dropdownRef} className="relative">
@@ -54,17 +41,19 @@ export default function LanguageSwitcher() {
         </button>
         {dropdownOpen && (
           <div className="absolute -left-4.5 mt-4 bg-white border border-gray-300 rounded shadow-md py-1 text-sm w-14 z-50">
-            {locales.map((lang) => (
-              <button
-                key={lang}
-                onClick={(e) => { e.stopPropagation(); handleLanguageChange(lang); }}
-                className={`w-full px-2 py-1 text-center hover:bg-gray-100 block ${
-                  locale === lang ? 'bg-[#A70909] text-white' : ''
-                }`}
-              >
-                {lang.toUpperCase()}
-              </button>
-            ))}
+          {locales.map((lang) => (
+            <Link
+              key={lang}
+              href={href}
+              locale={lang}
+              className={`w-full px-2 py-1 text-center hover:bg-gray-100 block ${
+                locale === lang ? 'bg-[#A70909] text-white' : ''
+              }`}
+              onClick={() => setDropdownOpen(false)}
+            >
+              {lang.toUpperCase()}
+            </Link>
+          ))}
           </div>
         )}
       </div>
@@ -72,21 +61,22 @@ export default function LanguageSwitcher() {
       {/* PC */}
       <div className="hidden lg:flex items-center space-x-2">
         {locales.map((lang) => (
-          <button
+          <Link
             key={lang}
-            onClick={(e) => { e.stopPropagation(); handleLanguageChange(lang); }}
+            href={href}
+            locale={lang}
             className={`flex items-center space-x-1 hover:opacity-80 transition-opacity ${
               locale === lang ? 'opacity-100' : 'opacity-50'
             }`}
           >
-            <Image 
-              src={localeInfo[lang as keyof typeof localeInfo]?.flag || `/flags/${lang}.png`} 
-              alt={localeInfo[lang as keyof typeof localeInfo]?.name || lang.toUpperCase()} 
-              width={24} 
-              height={16} 
+            <Image
+              src={localeInfo[lang as keyof typeof localeInfo]?.flag || `/flags/${lang}.png`}
+              alt={localeInfo[lang as keyof typeof localeInfo]?.name || lang.toUpperCase()}
+              width={24}
+              height={16}
             />
             <span className="text-sm text-black">{lang.toUpperCase()}</span>
-          </button>
+          </Link>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- upgrade `next-intl` to `^4.2.0`
- use the navigation utilities from `next-intl` in `LanguageSwitcher`

## Testing
- `npm run build` *(fails: Failed to fetch fonts during build)*

------
https://chatgpt.com/codex/tasks/task_e_685949f8168c83308d1ae700da17307f