### PR TITLE
Update LanguageSwitcher to use new next-intl client utilities

### DIFF
--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
 import { FaGlobe } from 'react-icons/fa'
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next-intl/link'
+import { usePathname, useSearchParams } from 'next-intl/client'
 import { useLocale } from 'next-intl'
 import { locales, localeInfo } from '../../../i18n'
 
@@ -13,7 +14,6 @@ export default function LanguageSwitcher() {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const locale = useLocale()
-  const router = useRouter()
 
   const toggleDropdown = () => setDropdownOpen((prev) => !prev)
 
@@ -38,12 +38,6 @@ export default function LanguageSwitcher() {
     return `/${targetLocale}${pathWithoutLocale}${query ? `?${query}` : ''}`
   }
 
-  const handleLanguageChange = (targetLocale: string) => {
-    setDropdownOpen(false)
-    const newPath = getLocalePath(targetLocale)
-    router.push(newPath)
-    router.refresh()
-  }
 
   return (
     <div ref={dropdownRef} className="relative">
@@ -55,15 +49,17 @@ export default function LanguageSwitcher() {
         {dropdownOpen && (
           <div className="absolute -left-4.5 mt-4 bg-white border border-gray-300 rounded shadow-md py-1 text-sm w-14 z-50">
             {locales.map((lang) => (
-              <button
+              <Link
                 key={lang}
-                onClick={(e) => { e.stopPropagation(); handleLanguageChange(lang); }}
+                href={getLocalePath(lang)}
+                locale={false}
                 className={`w-full px-2 py-1 text-center hover:bg-gray-100 block ${
                   locale === lang ? 'bg-[#A70909] text-white' : ''
                 }`}
+                onClick={() => setDropdownOpen(false)}
               >
                 {lang.toUpperCase()}
-              </button>
+              </Link>
             ))}
           </div>
         )}
@@ -72,21 +68,22 @@ export default function LanguageSwitcher() {
       {/* PC */}
       <div className="hidden lg:flex items-center space-x-2">
         {locales.map((lang) => (
-          <button
+          <Link
             key={lang}
-            onClick={(e) => { e.stopPropagation(); handleLanguageChange(lang); }}
+            href={getLocalePath(lang)}
+            locale={false}
             className={`flex items-center space-x-1 hover:opacity-80 transition-opacity ${
               locale === lang ? 'opacity-100' : 'opacity-50'
             }`}
           >
-            <Image 
-              src={localeInfo[lang as keyof typeof localeInfo]?.flag || `/flags/${lang}.png`} 
-              alt={localeInfo[lang as keyof typeof localeInfo]?.name || lang.toUpperCase()} 
-              width={24} 
-              height={16} 
+            <Image
+              src={localeInfo[lang as keyof typeof localeInfo]?.flag || `/flags/${lang}.png`}
+              alt={localeInfo[lang as keyof typeof localeInfo]?.name || lang.toUpperCase()}
+              width={24}
+              height={16}
             />
             <span className="text-sm text-black">{lang.toUpperCase()}</span>
-          </button>
+          </Link>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update navbar `LanguageSwitcher` imports for new `next-intl` utilities
- use `Link` for locale switches instead of router push

## Testing
- `npm run build` *(fails: Module not found for `next-intl/link`, fonts blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68595268651c83308c1b56caa697271b