### PR TITLE
Switch to local fonts

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,23 +3,39 @@ import { ReactNode } from 'react';
 import { notFound } from 'next/navigation';
 import { locales, Locale } from '../../../i18n';
 import '../globals.css';
-import { Prompt, Inter } from 'next/font/google';
+import localFont from 'next/font/local';
 import Navbar from '@/components/navbar/Navbar';
 import StructuredData from '@/components/StructuredData';
 import Footer from '@/components/Footer';
 import Script from 'next/script';
 import type { Metadata } from 'next';
 
-const fontTH = Prompt({
-  subsets: ['thai'],
+const fontTH = localFont({
   variable: '--font-th',
-  weight: ['400', '700']
+  src: [
+    {
+      path: '../../../public/fonts/Prompt/Prompt-Regular.ttf',
+      weight: '400'
+    },
+    {
+      path: '../../../public/fonts/Prompt/Prompt-Bold.ttf',
+      weight: '700'
+    }
+  ]
 });
 
-const fontEN = Inter({
-  subsets: ['latin'],
+const fontEN = localFont({
   variable: '--font-en',
-  weight: ['400', '700']
+  src: [
+    {
+      path: '../../../public/fonts/Inter/static/Inter_24pt-Regular.ttf',
+      weight: '400'
+    },
+    {
+      path: '../../../public/fonts/Inter/static/Inter_24pt-Bold.ttf',
+      weight: '700'
+    }
+  ]
 });
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {


### PR DESCRIPTION
## Summary
- use `next/font/local` to load Inter and Prompt fonts from `public/fonts`

## Testing
- `npm run lint`
- `npm run build` *(fails: Module not found: Package path ./link is not exported from package /workspace/virintira_web/node_modules/next-intl)*

------
https://chatgpt.com/codex/tasks/task_e_685963d969fc83308defe0ab1a5118c7