### PR TITLE
Update font instructions

### DIFF
--- a/Next-intl-setup.md
+++ b/Next-intl-setup.md
@@ -115,23 +115,27 @@ import { ReactNode } from 'react';
 import { notFound } from 'next/navigation';
 import { locales } from '../../../i18n';
 import '../globals.css';
-import { Prompt, Inter } from 'next/font/google';
+import localFont from 'next/font/local';
 import Navbar from '@/components/navbar/Navbar';
 import StructuredData from '@/components/StructuredData';
 import Footer from '@/components/Footer';
 import Script from 'next/script';
 import type { Metadata } from 'next';
 
-const fontTH = Prompt({
-  subsets: ['thai'],
+const fontTH = localFont({
   variable: '--font-th',
-  weight: ['400', '700']
+  src: [
+    { path: '../../../public/fonts/Prompt/Prompt-Regular.ttf', weight: '400' },
+    { path: '../../../public/fonts/Prompt/Prompt-Bold.ttf', weight: '700' }
+  ]
 });
 
-const fontEN = Inter({
-  subsets: ['latin'],
+const fontEN = localFont({
   variable: '--font-en',
-  weight: ['400', '700']
+  src: [
+    { path: '../../../public/fonts/Inter/static/Inter_24pt-Regular.ttf', weight: '400' },
+    { path: '../../../public/fonts/Inter/static/Inter_24pt-Bold.ttf', weight: '700' }
+  ]
 });
 
 export async function generateMetadata({ params: { locale } }: { params: { locale: string } }): Promise<Metadata> {

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-Inter and Prompt fonts are bundled under `public/fonts` and loaded via `next/font/local`.
+Inter and Prompt `.ttf` fonts are bundled under `public/fonts` and loaded via `next/font/local`.
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
- load local fonts in the next-intl setup instructions
- clarify README note about bundled `.ttf` fonts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859652377708330b8977f2b9acd3228