### PR TITLE
Call unstable_setRequestLocale on locale layout

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,4 +1,5 @@
 import { NextIntlClientProvider, useMessages } from 'next-intl';
+import { unstable_setRequestLocale } from 'next-intl/server';
 import { ReactNode } from 'react';
 import { notFound } from 'next/navigation';
 import { locales, Locale } from '../../../i18n';
@@ -131,5 +132,7 @@ export default async function LocaleLayout({
     notFound();
   }
 
+  unstable_setRequestLocale(locale);
+
   return <LocaleLayoutContent locale={locale}>{children}</LocaleLayoutContent>;
-} 
+}


### PR DESCRIPTION
## Summary
- import `unstable_setRequestLocale` from `next-intl/server`
- call `unstable_setRequestLocale(locale)` inside `LocaleLayout`

## Testing
- `npm run build` *(fails: Module '"next-intl/server"' has no exported member 'unstable_setRequestLocale')*

------
https://chatgpt.com/codex/tasks/task_e_68596c4079108330b94280fc2140952f