### PR TITLE
Fix setRequestLocale in locale layout

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,4 +1,5 @@
 import { NextIntlClientProvider, useMessages } from 'next-intl';
+import { setRequestLocale } from 'next-intl/server';
 import { ReactNode } from 'react';
 import { notFound } from 'next/navigation';
 import { locales, Locale } from '../../../i18n';
@@ -131,5 +132,7 @@ export default async function LocaleLayout({
     notFound();
   }
 
+  setRequestLocale(locale);
+
   return <LocaleLayoutContent locale={locale}>{children}</LocaleLayoutContent>;
-} 
+}


### PR DESCRIPTION
## Summary
- import `setRequestLocale` from `next-intl/server`
- invoke `setRequestLocale` before rendering the locale layout

## Testing
- `npx tsc --noEmit` *(fails: Module '"next-intl/navigation"' has no exported member 'Link')*
- `npm run build` *(fails: Attempted import error: 'Link' is not exported from 'next-intl/navigation')*

------
https://chatgpt.com/codex/tasks/task_e_68596f1daa248330870c37e631387388