### PR TITLE
Fix LanguageSwitcher imports

### DIFF
--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
 import { FaGlobe } from 'react-icons/fa'
-import { Link, usePathname, useSearchParams } from 'next-intl/navigation'
+import Link from 'next/link'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { useLocale } from 'next-intl'
 import { locales, localeInfo } from '../../../i18n'
 


### PR DESCRIPTION
## Summary
- update `LanguageSwitcher.tsx` imports to use `next/link` and `next/navigation`
- run TypeScript check and build

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a16c61b588330b005700608c7b8a5