### PR TITLE
Update LanguageSwitcher to use next-intl navigation

### DIFF
--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
 import { FaGlobe } from 'react-icons/fa'
-import Link from 'next/link'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { Link, usePathname, useSearchParams } from 'next-intl/navigation'
 import { useLocale } from 'next-intl'
 import { locales, localeInfo } from '../../../i18n'
 


### PR DESCRIPTION
## Summary
- switch `LanguageSwitcher` to next-intl's navigation utilities

## Testing
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a31c91fd083308594c592c3af9b02