### PR TITLE
fix: provide next-intl navigation utilities

### DIFF
--- a/i18n/navigation.ts
+++ b/i18n/navigation.ts
@@ -1,0 +1,6 @@
+import { createNavigation } from 'next-intl/navigation';
+import { locales } from '../i18n';
+
+export const { Link, usePathname, useRouter } =
+  createNavigation({ locales, localePrefix: 'as-needed' });
+

--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -52,7 +52,6 @@ export default function LanguageSwitcher() {
               <Link
                 key={lang}
                 href={getLocalePath(lang)}
-                locale={false}
                 className={`w-full px-2 py-1 text-center hover:bg-gray-100 block ${
                   locale === lang ? 'bg-[#A70909] text-white' : ''
                 }`}
@@ -71,7 +70,6 @@ export default function LanguageSwitcher() {
           <Link
             key={lang}
             href={getLocalePath(lang)}
-            locale={false}
             className={`flex items-center space-x-1 hover:opacity-80 transition-opacity ${
               locale === lang ? 'opacity-100' : 'opacity-50'
             }`}

--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
 import { FaGlobe } from 'react-icons/fa'
-import Link from 'next/link'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { Link, usePathname } from '../../../i18n/navigation'
+import { useSearchParams } from 'next/navigation'
 import { useLocale } from 'next-intl'
 import { locales, localeInfo } from '../../../i18n'
 


### PR DESCRIPTION
## Summary
- create navigation utilities with `createNavigation`
- use new Link and usePathname utilities in `LanguageSwitcher`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a4c818c3083309a467074fdea9f83