### PR TITLE
Use translations for unknown section and item

### DIFF
--- a/src/app/[locale]/under-construction/UnderConstructionContent.tsx
+++ b/src/app/[locale]/under-construction/UnderConstructionContent.tsx
@@ -23,8 +23,9 @@ function useIsMobile() {
 export default function UnderConstructionContent() {
   const t = useTranslations()
   const searchParams = useSearchParams()
-  const section = searchParams.get('section') || 'หมวดหมู่ไม่ระบุ'
-  const item = searchParams.get('item') || 'หัวข้อไม่ระบุ'
+  const section =
+    searchParams.get('section') || t('underConstruction.unknownSection')
+  const item = searchParams.get('item') || t('underConstruction.unknownItem')
 
   const [ctaExpanded, setCtaExpanded] = useState(false)
   const isMobile = useIsMobile()

--- a/src/messages/en/common.json
+++ b/src/messages/en/common.json
@@ -35,7 +35,9 @@
   },
   "underConstruction": {
     "heading": "The content for {section} / {item} is under development",
-    "message": "Please come back again soon"
+    "message": "Please come back again soon",
+    "unknownSection": "Unknown section",
+    "unknownItem": "Unknown item"
   },
   "megaMenu": {
     "registration": {

--- a/src/messages/th/common.json
+++ b/src/messages/th/common.json
@@ -35,7 +35,9 @@
   },
   "underConstruction": {
     "heading": "ข้อมูลในหน้า {section} / {item} อยู่ระหว่างการพัฒนา",
-    "message": "กรุณากลับมาใหม่เร็ว ๆ นี้"
+    "message": "กรุณากลับมาใหม่เร็ว ๆ นี้",
+    "unknownSection": "หมวดหมู่ไม่ระบุ",
+    "unknownItem": "หัวข้อไม่ระบุ"
   },
   "megaMenu": {
     "registration": {


### PR DESCRIPTION
## Summary
- use translation keys for under-construction fallbacks
- add `unknownSection` and `unknownItem` messages for English and Thai

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685cd91de540833092841a0e93ad248e