### PR TITLE
Update locale regex in LanguageSwitcher

### DIFF
--- a/i18n.ts
+++ b/i18n.ts
@@ -15,4 +15,4 @@ export const localeInfo = {
   ja: { name: '日本語', flag: '/flags/ja.png', dir: 'ltr' },
   ar: { name: 'العربية', flag: '/flags/ar.png', dir: 'rtl' },
   hi: { name: 'हिन्दी', flag: '/flags/hi.png', dir: 'ltr' },
-} as const; 
+} as const;

--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -31,7 +31,8 @@ export default function LanguageSwitcher() {
     }
   }, [])
 
-  const pathWithoutLocale = pathname.replace(/^\/(th|en)/, '') || '/'
+  const localeRegex = new RegExp(`^/(${locales.join('|')})`)
+  const pathWithoutLocale = pathname.replace(localeRegex, '') || '/'
   const query = searchParams.toString()
   const href = `${pathWithoutLocale}${query ? `?${query}` : ''}`
 


### PR DESCRIPTION
## Summary
- dynamically build regex from available locales for LanguageSwitcher
- ensure `i18n.ts` ends with newline

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d652dd058833088e0dd0d5743fb59